### PR TITLE
Added stages to force install of ppa before installing packages

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,18 +11,17 @@ class zfs(
 
   } else {
 
-    include apt
-    package {'python-software-properties':
-      ensure => present,
+    stage { 'ppa':
+      before => Stage['main'],
     }
-
-    apt::ppa { 'ppa:zfs-native/stable/ubuntu': 
-      require => Package['python-software-properties'], 
-    }
-
+    
+    # install the ppa repos
+    class {'repo':
+      stage => ppa,
+    }->
     package {'ubuntu-zfs':
       ensure => latest,
-    }
+    }->
     package {'zfs-auto-snapshot':
       ensure => latest,
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,28 +2,36 @@
 class zfs(
   $fuse = false,
 ){
-
-  if $fuse { 
-
-    package { 'zfs-fuse':
-      ensure => present,
+  case $::operatingsystem {
+    ubuntu : {
+      if $fuse { 
+        package { 'zfs-fuse':
+          ensure => present,
+        }
+      } else {
+        stage { 'ppa':
+          before => Stage['main'],
+        }
+        # install the ppa repos
+        class {'repo':
+          stage => ppa,
+        }->
+        package {'ubuntu-zfs':
+          ensure => latest,
+        }
+        #ubuntu 13.10 does not have this package!
+        case $::lsbdistrelease {
+          10.04,12.04,12.10,13.04 : {
+            package {'zfs-auto-snapshot':
+              ensure  => latest,
+              require => Package['ubuntu-zfs'],
+            }
+          }
+        }
+      }
     }
-
-  } else {
-
-    stage { 'ppa':
-      before => Stage['main'],
-    }
-    
-    # install the ppa repos
-    class {'repo':
-      stage => ppa,
-    }->
-    package {'ubuntu-zfs':
-      ensure => latest,
-    }->
-    package {'zfs-auto-snapshot':
-      ensure => latest,
+    default : {
+      fail("zfs is not currently supported on ${::operatingsystem}")
     }
   }
 }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,0 +1,13 @@
+# == Class zfs::repo
+# Need to put ppa's in a seperate stage due to
+# having to initiate the add-apt-repo before using the package.
+class zfs::repo {
+    include apt
+    package {'python-software-properties':
+      ensure => present,
+    }
+
+    apt::ppa { 'ppa:zfs-native/stable': 
+      require => Package['python-software-properties'], 
+    }
+}


### PR DESCRIPTION
Its possible for packages to be attempted to install before the ppa is added.  Stages it the only way that I have been able to force the ppa to run before packages are installed.  This update adds stages to ensure that it works.
